### PR TITLE
[Bherly] Refactor producer router to send AppSecret as Context

### DIFF
--- a/router/producer_proxy_handler.go
+++ b/router/producer_proxy_handler.go
@@ -13,14 +13,16 @@ type ProducerProxyHandler interface {
 }
 
 type producerProxyHandler struct {
-	target  *url.URL
-	profile Profile
+	target    *url.URL
+	profile   Profile
+	appSecret string
 }
 
-func NewProducerProxyHandler(target *url.URL, profile Profile) ProducerProxyHandler {
+func NewProducerProxyHandler(target *url.URL, profile Profile, appSecret string) ProducerProxyHandler {
 	return &producerProxyHandler{
-		target:  target,
-		profile: profile,
+		target:    target,
+		profile:   profile,
+		appSecret: appSecret,
 	}
 }
 
@@ -53,6 +55,7 @@ func (h producerProxyHandler) Director(req *http.Request) {
 	}
 
 	timber["_ctx"] = h.timberContext()
+
 	b, _ = json.Marshal(timber)
 
 	req.ContentLength = int64(len(b))
@@ -68,5 +71,6 @@ func (h producerProxyHandler) timberContext() TimberContext {
 		ESIndexPrefix:          h.profile.Meta.Elasticsearch.IndexPrefix,
 		ESDocumentType:         h.profile.Meta.Elasticsearch.DocumentType,
 		AppMaxTPS:              h.profile.MaxTps,
+		AppSecret:              h.appSecret,
 	}
 }

--- a/router/producer_proxy_handler_test.go
+++ b/router/producer_proxy_handler_test.go
@@ -19,8 +19,9 @@ func TestProducerProxyHandler(t *testing.T) {
 		Host:   "localhost:12345",
 	}
 
+	secret := "some-secret-1234"
 	profile := Profile{}
-	proxyHandler := NewProducerProxyHandler(url, profile)
+	proxyHandler := NewProducerProxyHandler(url, profile, secret)
 
 	body := strings.NewReader(`
 	{
@@ -48,6 +49,7 @@ func TestProducerProxyHandler(t *testing.T) {
 		"kafka_partition":          0,
 		"kafka_replication_factor": 0,
 		"es_document_type":         "",
+		"app_secret":               secret,
 	}
 	bref, _ := json.Marshal(refCtx)
 	FatalIf(t, string(b) != string(bref), "Context not found or invalid context inserted")

--- a/router/producer_router.go
+++ b/router/producer_router.go
@@ -71,7 +71,7 @@ func (p *producerRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		Host:   fmt.Sprintf("%s:%d", srv.ServiceAddress, srv.ServicePort),
 	}
 
-	h := NewProducerProxyHandler(url, *profile)
+	h := NewProducerProxyHandler(url, *profile, secret)
 	proxy := &httputil.ReverseProxy{
 		Director: h.Director,
 	}

--- a/router/timber_context.go
+++ b/router/timber_context.go
@@ -7,4 +7,5 @@ type TimberContext struct {
 	ESIndexPrefix          string `json:"es_index_prefix"`
 	ESDocumentType         string `json:"es_document_type"`
 	AppMaxTPS              int    `json:"app_max_tps"`
+	AppSecret              string `json:"app_secret"`
 }


### PR DESCRIPTION
Since BaritoFlow cannot related into single application only, we need to send `AppSecret` to BaritoFlow Producer as part of Timber Context. So we can remove `AppSecret` initialization from ENV vars in BaritoFlow.